### PR TITLE
RFC: Replace libvirt with libxl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES=-package str,lwt,dns.lwt,libvirt,cmdliner
+PACKAGES=-package str,lwt,dns.lwt,xenlight,xenlight.xentoollog,cmdliner,uuidm,xenstore,xenstore.client,xenstore_transport,xenstore_transport.lwt
 INCLUDE=
 OPT=-linkpkg -g 
 OCAMLOPT=ocamlopt -w A-4-44
@@ -8,6 +8,10 @@ all: jitsu
 
 jitsu: jitsu.ml main.ml
 	ocamlfind $(OCAMLOPT) $(INCLUDE) $(PACKAGES) $(OPT) $(FILES) -o jitsu
+
+.PHONY: install-deps
+install-deps:
+	opam install $(PACKAGES)
 
 clean:
 	rm -f jitsu jitsu.cmx jitsu.cmi jitsu.o main.o main.cmx main.cmi

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ make
 You should now be able to start jitsu:
 
 ```
-sudo ./jitsu www.openmirage.org,192.168.0.22,/unikernels/mirage-www.xen,32768
+sudo ./jitsu --bridge=xenbr0 www.openmirage.org,192.168.0.22,/unikernels/mirage-www.xen,32768
 ```
 
 The command above connects to a local Xen-server (from dom0) through libxl and starts the DNS server.

--- a/README.md
+++ b/README.md
@@ -2,24 +2,30 @@
 
 Jitsu is a forwarding DNS server that automatically starts virtual machines (VMs) on demand. When a DNS query is received, jitsu first checks for a local VM that is mapped to the requested domain. If a VM is found, the VM is started and its IP is returned to the client. Otherwise, the request is forwarded to the next DNS server. If no DNS requests are received for the VM within a given timeout period it is automatically stopped. 
 
-Although Jitsu can be used with any VM that can be controlled with libvirt, it is mainly intended for use with [unikernels](http://www.openmirage.org) that can be started quickly and be able to respond to the client request within the time it takes to send the DNS response. 
+Jitsu is mainly intended for use with Xen
+[unikernels](http://www.openmirage.org) that can be started quickly and be able to respond to the client request within the time it takes to send the DNS response. 
 
 ## Getting started ##
 
-Jitsu requires the libraries dns, lwt, libvirt and cmdliner, which can be installed with [opam](https://opam.ocaml.org). Run make to compile:
+Jitsu requires several external libraries from
+[opam](https://opam.ocaml.org). Run make to compile:
 
 ```
-opam install dns lwt libvirt cmdliner
+make install-deps
 make
 ```
 
 You should now be able to start jitsu:
 
 ```
-sudo ./jitsu www.openmirage.org,192.168.0.22,mirage-www -c xen:/// 
+sudo ./jitsu www.openmirage.org,192.168.0.22,/unikernels/mirage-www.xen,32768
 ```
 
-The command above connects to a local Xen-server (from dom0) through libvirt and starts the DNS server. Requests for www.openmirage.org will be redirected to the Xen-VM called "mirage-www" with IP 192.168.0.22. If "mirage-www" is not running, jitsu will start it automatically before responding to the DNS request.
+The command above connects to a local Xen-server (from dom0) through libxl and starts the DNS server.
+Requests for www.openmirage.org will be redirected to the Xen unikernel with filename
+`/unikernels/mirage-www.xen` configured with 32MiB of RAM and with IP 192.168.0.22.
+If `/unikernels/mirage-www.xen` is not running, jitsu will start it automatically before
+responding to the DNS request.
 
 See [below](#options) or run ./jitsu --help for more options.
 

--- a/jitsu.ml
+++ b/jitsu.ml
@@ -233,8 +233,8 @@ let start_vm t vm =
       blocking_xenlight
         (fun () ->
           try
-            let _domid = Xenlight.Domain.create_restore context (domain_config vm) (Lwt_unix.unix_file_descr fd, params) () in
-            ()
+            let domid = Xenlight.Domain.create_restore context (domain_config vm) (Lwt_unix.unix_file_descr fd, params) () in
+            Xenlight.Domain.unpause context domid
           with e ->
             fprintf stderr "Resume failed with: %s. Consider deleting suspend file %s.\n%!" (Printexc.to_string e) suspend_image
         );
@@ -244,8 +244,8 @@ let start_vm t vm =
       blocking_xenlight
         (fun () ->
           try
-            let _domid = Xenlight.Domain.create_new context (domain_config vm) () in
-            ()
+            let domid = Xenlight.Domain.create_new context (domain_config vm) () in
+            Xenlight.Domain.unpause context domid
           with e ->
             fprintf stderr "Create failed with: %s.\n%!" (Printexc.to_string e);
         );

--- a/jitsu.mli
+++ b/jitsu.mli
@@ -37,9 +37,9 @@ val process: t -> Dns.Packet.t Dns_server.process
 (** Process function for ocaml-dns. Starts new VMs from DNS queries or
     forwards request to a fallback resolver *)
 
-val add_vm: t -> domain:string -> name:string -> memory_kb:int64 ->
+val add_vm: t -> domain:string -> name:string -> bridge:string -> memory_kb:int64 ->
   Ipaddr.V4.t -> vm_stop_mode -> delay:float -> ttl:int -> unit Lwt.t
-(** [add_vm t domain name memory_kb ip stop_mode delay ttl] adds a VM to be
+(** [add_vm t domain name bridge memory_kb ip stop_mode delay ttl] adds a VM to be
     monitored by jitsu.  FIXME. *)
 
 val stop_expired_vms: t -> unit Lwt.t

--- a/jitsu.mli
+++ b/jitsu.mli
@@ -30,18 +30,18 @@ type vm_stop_mode = VmStopDestroy | VmStopSuspend | VmStopShutdown
 type t
 (** The type of Jitsu states. *)
 
-val create: (string -> unit) -> string -> Dns_resolver_unix.t -> int -> t
-(** [create log_function name resolver vm_count] creates a new Jitsu instance. FIXME. *)
+val create: (string -> unit) -> Dns_resolver_unix.t -> int -> t
+(** [create resolver vm_count] creates a new Jitsu instance. FIXME. *)
 
 val process: t -> Dns.Packet.t Dns_server.process
 (** Process function for ocaml-dns. Starts new VMs from DNS queries or
     forwards request to a fallback resolver *)
 
-val add_vm: t -> domain:string -> name:string -> Ipaddr.V4.t -> vm_stop_mode ->
-  delay:float -> ttl:int -> unit Lwt.t
-(** [add_vm t domain name ip stop_mode delay ttl] adds a VM to be
+val add_vm: t -> domain:string -> name:string -> memory_kb:int64 ->
+  Ipaddr.V4.t -> vm_stop_mode -> delay:float -> ttl:int -> unit Lwt.t
+(** [add_vm t domain name memory_kb ip stop_mode delay ttl] adds a VM to be
     monitored by jitsu.  FIXME. *)
 
-val stop_expired_vms: t -> unit
+val stop_expired_vms: t -> unit Lwt.t
 (** Iterate through the internal VM table and stop VMs that haven't
     received requests for more than [ttl*2] seconds. *)

--- a/main.ml
+++ b/main.ml
@@ -28,14 +28,10 @@ let info =
      stopped." in
   let man = [
     `S "EXAMPLES";
-    `P "jitsu -c xen:/// -f 8.8.8.8 -m destroy mirage.org,10.0.0.1,mirage-www";
-    `P "Connect to Xen. Start VM 'mirage-www' on requests for mirage.org and \
+    `P "jitsu -f 8.8.8.8 -m destroy mirage.org,10.0.0.1,/unikernels/mirage-www.xen,32768";
+    `P "Start unikernel '/unikernels/mirage-www.xen' with 32MiB on requests for mirage.org and \
         return IP 10.0.0.1 when VM is running. Forward unknown requests to \
         8.8.8.8 (Google). Expired VMs are destroyed.";
-    `P "jitsu -c vbox:///session -m suspend home.local,192.168.0.1,ubuntu -t 60";
-    `P "Connect to Virtualbox. Start VM 'ubuntu' on requests for home.local \
-        and return IP 192.168.0.1. Forward unknown requests to system default. \
-        Expired VMs are suspended after 120 seconds (2 x DNS ttl).";
     `S "AUTHORS";
     `P "Magnus Skjegstad <magnus@skjegstad.com>" ;
     `S "BUGS";
@@ -49,12 +45,6 @@ let bindaddr =
 let bindport =
   let doc = "UDP port to listen for DNS queries" in
   Arg.(value & opt int 53 & info ["l"; "listen"] ~docv:"PORT" ~doc)
-
-let connstr =
-  let doc =
-    "libvirt connection string (e.g. xen+ssh://x.x.x.x/system or vbox:///session)"
-  in
-  Arg.(value & opt string "xen:///" & info ["c"; "connect"] ~docv:"CONNECT" ~doc)
 
 let forwarder =
   let doc =
@@ -77,10 +67,10 @@ let response_delay =
 
 let map_domain =
   let doc =
-    "Maps DOMAIN to a VM and IP. VM must match a VM available through libvirt \
+    "Maps DOMAIN to a VM, IP and memory in KiB. VM must match a VM available through libvirt \
      (see virsh list --all)." in
-  Arg.(non_empty & pos_all (t3 ~sep:',' string string string) [] & info []
-         ~docv:"DOMAIN,IP,VM" ~doc)
+  Arg.(non_empty & pos_all (t4 ~sep:',' string string string int64) [] & info []
+         ~docv:"DOMAIN,IP,VM,KIB" ~doc)
 
 let ttl =
   let doc =
@@ -111,14 +101,19 @@ let or_warn msg f =
   try f () with
   | Failure m -> (log (Printf.sprintf "Warning: %s\nReceived exception: %s" msg m)); ()
 
-let jitsu connstr bindaddr bindport forwarder forwardport response_delay
+let spinner = [| '-'; '\\'; '|'; '/' |]
+
+let jitsu bindaddr bindport forwarder forwardport response_delay
     map_domain ttl vm_stop_mode =
-  let rec maintenance_thread t timeout =
-    Lwt_unix.sleep timeout >>= fun () ->
-    log ".";
-    or_warn "Unable to stop expired VMs" (fun () -> Jitsu.stop_expired_vms t);
-    maintenance_thread t timeout;
-  in
+  let maintenance_thread t timeout =
+    let rec loop i =
+      let i = if i >= Array.length spinner then 0 else i in
+      Lwt_unix.sleep timeout >>= fun () ->
+      Printf.printf "\b%c%!" spinner.(i);
+      Jitsu.stop_expired_vms t
+      >>= fun () ->
+      loop (i + 1) in
+    loop 0 in
   Lwt_main.run (
     ((match forwarder with
         | "" -> Dns_resolver_unix.create () (* use resolv.conf *)
@@ -128,13 +123,13 @@ let jitsu connstr bindaddr bindport forwarder forwardport response_delay
           Dns_resolver_unix.create ~config:config ()
       )
      >>= fun forward_resolver ->
-     log (Printf.sprintf "Connecting to %s...\n" connstr);
-     let t = or_abort (fun () -> Jitsu.create log connstr forward_resolver ttl) in
+     let t = Jitsu.create log forward_resolver ttl in
      Lwt.choose [(
          (* main thread, DNS server *)
-         let triple (dns,ip,name) =
-           log (Printf.sprintf "Adding domain '%s' for VM '%s' with ip %s\n" dns name ip);
-           or_abort (fun () -> Jitsu.add_vm t ~domain:dns ~name (Ipaddr.V4.of_string_exn ip) vm_stop_mode ~delay:response_delay ~ttl)
+         let triple (dns,ip,name,memory_kb) =
+           log (Printf.sprintf "Adding domain '%s' for VM '%s' with ip %s and %Ld KiB of RAM\n" dns name ip memory_kb);
+           Jitsu.add_vm t ~domain:dns ~name ~memory_kb (Ipaddr.V4.of_string_exn ip)
+             vm_stop_mode ~delay:response_delay ~ttl
          in
          Lwt_list.iter_p triple map_domain
          >>= fun () ->
@@ -148,7 +143,7 @@ let jitsu connstr bindaddr bindport forwarder forwardport response_delay
   )
 
 let jitsu_t =
-  Term.(pure jitsu $ connstr $ bindaddr $ bindport $ forwarder $ forwardport
+  Term.(pure jitsu $ bindaddr $ bindport $ forwarder $ forwardport
         $ response_delay $ map_domain $ ttl $ vm_stop_mode )
 
 let () =


### PR DESCRIPTION
This simplifies the stack by removing libvirt. Noteworthy implications:

- must be run on Xen, in dom0 as root
- rather than a VM name it takes a Unikernel filename (and memory size)
- the VM configuration has to be set here (because jitsu must generate it because libxl doesn't store it unlike libvirt or xapi)